### PR TITLE
Use MDPopup instead of FLAlertLayer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <Geode/Geode.hpp>
 #include <Geode/utils/web.hpp>
 #include <Geode/loader/Event.hpp>
+#include <Geode/ui/MDPopup.hpp>
 #include <vector>
 #include <string>
 #include <stdio.h>
@@ -474,7 +475,7 @@ queued deaths while the server was offline. Normally, this should not get you ra
 limited, but for your safety, the death backlog has been forcefully emptied.";
 		content += "\n\nIf you are using a VPN, you may be rate limited because you \
 share an IP with others. I strongly advise you to turn it off.";
-		FLAlertLayer::create(
+		MDPopup::create(
 			"Spam Warning",
 			content,
 			"Dismiss"


### PR DESCRIPTION
Using FLAlertLayer causes this to happen
![image](https://github.com/user-attachments/assets/1d971468-5dcd-4ba4-ad40-579566c67bc9)

While MDPopup:

![image](https://github.com/user-attachments/assets/d9482d99-fb09-40d2-8cdc-d8de3cff8710)

You do have to scroll a little bit to see the full message but if you're okay with that you can use MDPopup or change the height